### PR TITLE
Update uniswap link to a "buy smol" tx

### DIFF
--- a/src/components/Footer/components/Nav.tsx
+++ b/src/components/Footer/components/Nav.tsx
@@ -12,7 +12,7 @@ const Nav: React.FC = () => {
       </StyledLink>
       <StyledLink
         target="_blank"
-        href="https://app.uniswap.org/#/swap?inputCurrency=0x2216e873ea4282ebef7a02ac5aea220be6391a7c&outputCurrency=ETH"
+        href="https://app.uniswap.org/#/swap?inuptCurrency=ETH&outputCurrency=0x2216e873ea4282ebef7a02ac5aea220be6391a7c&exactField=output&exactAmount=100"
       >
         uniswap smol-eth
       </StyledLink>


### PR DESCRIPTION
The "uniswap smol-eth" link in the footer currently sends you to a swap that sells smol. To make life easier for new buyers, this commit updates the link to load a 100 SMOL buy.

![uniswap1](https://user-images.githubusercontent.com/72024253/94512716-b70d2880-01ea-11eb-8c5e-2ae1931538ae.PNG)
![uniswap2](https://user-images.githubusercontent.com/72024253/94512720-b83e5580-01ea-11eb-9fe1-4e4ac7f8cbb2.PNG)
